### PR TITLE
Revert "Fix deletion of VkSemaphores in VulkanManager."

### DIFF
--- a/libs/hwui/renderthread/VulkanManager.cpp
+++ b/libs/hwui/renderthread/VulkanManager.cpp
@@ -58,6 +58,10 @@ static void free_features_extensions_structs(const VkPhysicalDeviceFeatures2& fe
 #define GET_DEV_PROC(F) m##F = (PFN_vk##F)vkGetDeviceProcAddr(mDevice, "vk" #F)
 
 void VulkanManager::destroy() {
+    // We don't need to explicitly free the command buffer since it automatically gets freed when we
+    // delete the VkCommandPool below.
+    mDummyCB = VK_NULL_HANDLE;
+
     if (VK_NULL_HANDLE != mCommandPool) {
         mDestroyCommandPool(mDevice, mCommandPool, nullptr);
         mCommandPool = VK_NULL_HANDLE;
@@ -370,6 +374,12 @@ void VulkanManager::initialize() {
     }
     LOG_ALWAYS_FATAL_IF(mCommandPool == VK_NULL_HANDLE);
 
+    if (!setupDummyCommandBuffer()) {
+        this->destroy();
+        // Pass through will crash on next line.
+    }
+    LOG_ALWAYS_FATAL_IF(mDummyCB == VK_NULL_HANDLE);
+
     mGetDeviceQueue(mDevice, mPresentQueueIndex, 0, &mPresentQueue);
 
     if (Properties::enablePartialUpdates && Properties::useBufferAge) {
@@ -476,22 +486,6 @@ Frame VulkanManager::dequeueNextBuffer(VulkanSurface* surface) {
     return Frame(surface->logicalWidth(), surface->logicalHeight(), bufferAge);
 }
 
-struct DestroySemaphoreInfo {
-    PFN_vkDestroySemaphore mDestroyFunction;
-    VkDevice mDevice;
-    VkSemaphore mSemaphore;
-
-    DestroySemaphoreInfo(PFN_vkDestroySemaphore destroyFunction, VkDevice device,
-            VkSemaphore semaphore)
-            : mDestroyFunction(destroyFunction), mDevice(device), mSemaphore(semaphore) {}
-};
-
-static void destroy_semaphore(void* context) {
-    DestroySemaphoreInfo* info = reinterpret_cast<DestroySemaphoreInfo*>(context);
-    info->mDestroyFunction(info->mDevice, info->mSemaphore, nullptr);
-    delete info;
-}
-
 void VulkanManager::swapBuffers(VulkanSurface* surface, const SkRect& dirtyRect) {
     if (CC_UNLIKELY(Properties::waitForGpuCompletion)) {
         ATRACE_NAME("Finishing GPU work");
@@ -521,12 +515,9 @@ void VulkanManager::swapBuffers(VulkanSurface* surface, const SkRect& dirtyRect)
     backendSemaphore.initVulkan(semaphore);
 
     int fenceFd = -1;
-    DestroySemaphoreInfo* destroyInfo = new DestroySemaphoreInfo(mDestroySemaphore, mDevice,
-                                                                 semaphore);
     GrSemaphoresSubmitted submitted =
             bufferInfo->skSurface->flush(SkSurface::BackendSurfaceAccess::kPresent,
-                                         kNone_GrFlushFlags, 1, &backendSemaphore,
-                                         destroy_semaphore, destroyInfo);
+                                         SkSurface::kNone_FlushFlags, 1, &backendSemaphore);
     if (submitted == GrSemaphoresSubmitted::kYes) {
         VkSemaphoreGetFdInfoKHR getFdInfo;
         getFdInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
@@ -542,6 +533,12 @@ void VulkanManager::swapBuffers(VulkanSurface* surface, const SkRect& dirtyRect)
     }
 
     surface->presentCurrentBuffer(dirtyRect, fenceFd);
+
+    // Exporting a semaphore with copy transference via vkGetSemaphoreFdKHR, has the same effect of
+    // destroying the semaphore and creating a new one with the same handle, and the payloads
+    // ownership is move to the Fd we created. Thus the semaphore is in a state that we can delete
+    // it and we don't need to wait on the command buffer we submitted to finish.
+    mDestroySemaphore(mDevice, semaphore, nullptr);
 }
 
 void VulkanManager::destroySurface(VulkanSurface* surface) {
@@ -567,7 +564,38 @@ VulkanSurface* VulkanManager::createSurface(ANativeWindow* window, ColorMode col
                                  *this, extraBuffers);
 }
 
-status_t VulkanManager::fenceWait(sp<Fence>& fence, GrContext* grContext) {
+bool VulkanManager::setupDummyCommandBuffer() {
+    if (mDummyCB != VK_NULL_HANDLE) {
+        return true;
+    }
+
+    VkCommandBufferAllocateInfo commandBuffersInfo;
+    memset(&commandBuffersInfo, 0, sizeof(VkCommandBufferAllocateInfo));
+    commandBuffersInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    commandBuffersInfo.pNext = nullptr;
+    commandBuffersInfo.commandPool = mCommandPool;
+    commandBuffersInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    commandBuffersInfo.commandBufferCount = 1;
+
+    VkResult err = mAllocateCommandBuffers(mDevice, &commandBuffersInfo, &mDummyCB);
+    if (err != VK_SUCCESS) {
+        // It is probably unnecessary to set this back to VK_NULL_HANDLE, but we set it anyways to
+        // make sure the driver didn't set a value and then return a failure.
+        mDummyCB = VK_NULL_HANDLE;
+        return false;
+    }
+
+    VkCommandBufferBeginInfo beginInfo;
+    memset(&beginInfo, 0, sizeof(VkCommandBufferBeginInfo));
+    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
+
+    mBeginCommandBuffer(mDummyCB, &beginInfo);
+    mEndCommandBuffer(mDummyCB);
+    return true;
+}
+
+status_t VulkanManager::fenceWait(sp<Fence>& fence) {
     if (!hasVkContext()) {
         ALOGE("VulkanManager::fenceWait: VkDevice not initialized");
         return INVALID_OPERATION;
@@ -600,22 +628,36 @@ status_t VulkanManager::fenceWait(sp<Fence>& fence, GrContext* grContext) {
 
     err = mImportSemaphoreFdKHR(mDevice, &importInfo);
     if (VK_SUCCESS != err) {
-        mDestroySemaphore(mDevice, semaphore, nullptr);
         ALOGE("Failed to import semaphore, err: %d", err);
         return UNKNOWN_ERROR;
     }
 
-    GrBackendSemaphore beSemaphore;
-    beSemaphore.initVulkan(semaphore);
+    LOG_ALWAYS_FATAL_IF(mDummyCB == VK_NULL_HANDLE);
 
-    // Skia takes ownership of the semaphore and will delete it once the wait has finished.
-    grContext->wait(1, &beSemaphore);
-    grContext->flush();
+    VkPipelineStageFlags waitDstStageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
+    VkSubmitInfo submitInfo;
+    memset(&submitInfo, 0, sizeof(VkSubmitInfo));
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.waitSemaphoreCount = 1;
+    // Wait to make sure aquire semaphore set above has signaled.
+    submitInfo.pWaitSemaphores = &semaphore;
+    submitInfo.pWaitDstStageMask = &waitDstStageFlags;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &mDummyCB;
+    submitInfo.signalSemaphoreCount = 0;
+
+    mQueueSubmit(mGraphicsQueue, 1, &submitInfo, VK_NULL_HANDLE);
+
+    // On Android when we import a semaphore, it is imported using temporary permanence. That
+    // means as soon as we queue the semaphore for a wait it reverts to its previous permanent
+    // state before importing. This means it will now be in an idle state with no pending
+    // signal or wait operations, so it is safe to immediately delete it.
+    mDestroySemaphore(mDevice, semaphore, nullptr);
     return OK;
 }
 
-status_t VulkanManager::createReleaseFence(sp<Fence>& nativeFence, GrContext* grContext) {
+status_t VulkanManager::createReleaseFence(sp<Fence>& nativeFence) {
     if (!hasVkContext()) {
         ALOGE("VulkanManager::createReleaseFence: VkDevice not initialized");
         return INVALID_OPERATION;
@@ -637,20 +679,20 @@ status_t VulkanManager::createReleaseFence(sp<Fence>& nativeFence, GrContext* gr
         return INVALID_OPERATION;
     }
 
-    GrBackendSemaphore backendSemaphore;
-    backendSemaphore.initVulkan(semaphore);
+    LOG_ALWAYS_FATAL_IF(mDummyCB == VK_NULL_HANDLE);
 
-    DestroySemaphoreInfo* destroyInfo = new DestroySemaphoreInfo(mDestroySemaphore, mDevice,
-                                                                 semaphore);
-    GrSemaphoresSubmitted submitted =
-            grContext->flush(kNone_GrFlushFlags, 1, &backendSemaphore,
-                             destroy_semaphore, destroyInfo);
+    VkSubmitInfo submitInfo;
+    memset(&submitInfo, 0, sizeof(VkSubmitInfo));
+    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submitInfo.waitSemaphoreCount = 0;
+    submitInfo.pWaitSemaphores = nullptr;
+    submitInfo.pWaitDstStageMask = nullptr;
+    submitInfo.commandBufferCount = 1;
+    submitInfo.pCommandBuffers = &mDummyCB;
+    submitInfo.signalSemaphoreCount = 1;
+    submitInfo.pSignalSemaphores = &semaphore;
 
-    if (submitted == GrSemaphoresSubmitted::kNo) {
-        ALOGE("VulkanManager::createReleaseFence: Failed to submit semaphore");
-        mDestroySemaphore(mDevice, semaphore, nullptr);
-        return INVALID_OPERATION;
-    }
+    mQueueSubmit(mGraphicsQueue, 1, &submitInfo, VK_NULL_HANDLE);
 
     VkSemaphoreGetFdInfoKHR getFdInfo;
     getFdInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
@@ -666,6 +708,12 @@ status_t VulkanManager::createReleaseFence(sp<Fence>& nativeFence, GrContext* gr
         return INVALID_OPERATION;
     }
     nativeFence = new Fence(fenceFd);
+
+    // Exporting a semaphore with copy transference via vkGetSemahporeFdKHR, has the same effect of
+    // destroying the semaphore and creating a new one with the same handle, and the payloads
+    // ownership is move to the Fd we created. Thus the semahpore is in a state that we can delete
+    // it and we don't need to wait on the command buffer we submitted to finish.
+    mDestroySemaphore(mDevice, semaphore, nullptr);
 
     return OK;
 }

--- a/libs/hwui/renderthread/VulkanManager.h
+++ b/libs/hwui/renderthread/VulkanManager.h
@@ -70,11 +70,10 @@ public:
     void destroy();
 
     // Inserts a wait on fence command into the Vulkan command buffer.
-    status_t fenceWait(sp<Fence>& fence, GrContext* grContext);
+    status_t fenceWait(sp<Fence>& fence);
 
-    // Creates a fence that is signaled when all the pending Vulkan commands are finished on the
-    // GPU.
-    status_t createReleaseFence(sp<Fence>& nativeFence, GrContext* grContext);
+    // Creates a fence that is signaled, when all the pending Vulkan commands are flushed.
+    status_t createReleaseFence(sp<Fence>& nativeFence);
 
     // Returned pointers are owned by VulkanManager.
     // An instance of VkFunctorInitParams returned from getVkFunctorInitParams refers to
@@ -90,6 +89,7 @@ private:
     // Sets up the VkInstance and VkDevice objects. Also fills out the passed in
     // VkPhysicalDeviceFeatures struct.
     void setupDevice(GrVkExtensions&, VkPhysicalDeviceFeatures2&);
+    bool setupDummyCommandBuffer();
 
     // simple wrapper class that exists only to initialize a pointer to NULL
     template <typename FNPTR_TYPE>
@@ -163,6 +163,8 @@ private:
     uint32_t mPresentQueueIndex;
     VkQueue mPresentQueue = VK_NULL_HANDLE;
     VkCommandPool mCommandPool = VK_NULL_HANDLE;
+
+    VkCommandBuffer mDummyCB = VK_NULL_HANDLE;
 
     // Variables saved to populate VkFunctorInitParams.
     static const uint32_t mAPIVersion = VK_MAKE_VERSION(1, 1, 0);

--- a/libs/hwui/surfacetexture/ImageConsumer.cpp
+++ b/libs/hwui/surfacetexture/ImageConsumer.cpp
@@ -224,8 +224,7 @@ sk_sp<SkImage> ImageConsumer::dequeueImage(bool* queueEmpty, SurfaceTexture& st,
             uirenderer::RenderPipelineType::SkiaGL) {
             err = renderState.getRenderThread().eglManager().fenceWait(item.mFence);
         } else {
-            err = renderState.getRenderThread().vulkanManager().fenceWait(
-                    item.mFence, renderState.getRenderThread().getGrContext());
+            err = renderState.getRenderThread().vulkanManager().fenceWait(item.mFence);
         }
         if (err != OK) {
             st.releaseBufferLocked(slot, st.mSlots[slot].mGraphicBuffer, EGL_NO_DISPLAY,
@@ -247,8 +246,7 @@ sk_sp<SkImage> ImageConsumer::dequeueImage(bool* queueEmpty, SurfaceTexture& st,
             err = eglManager.createReleaseFence(st.mUseFenceSync, &mImageSlots[slot].eglFence(),
                                                 releaseFence);
         } else {
-            err = renderState.getRenderThread().vulkanManager().createReleaseFence(
-                    releaseFence, renderState.getRenderThread().getGrContext());
+            err = renderState.getRenderThread().vulkanManager().createReleaseFence(releaseFence);
         }
         if (OK != err) {
             st.releaseBufferLocked(slot, st.mSlots[slot].mGraphicBuffer, EGL_NO_DISPLAY,


### PR DESCRIPTION
* Some devices have set HWUI to use skiavk, but camera turns into a "slideshow" then.
  Reverting this patch fixes this behaviour.
* This reverts commit d92a9b158e8a473cd7860f2ea6cc9090fc294f78.

Change-Id: I3eb87179bd2343e08ad7c10ca4bcd67d98c8b736
(cherry picked from commit c434c38cc7bd38f700c564ac41a178e0651b7a35)